### PR TITLE
Add missing RustLang scenarios

### DIFF
--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -968,6 +968,90 @@ class GoLanguage:
     return 'go'
 
 
+class RustLanguage:
+
+  def __init__(self):
+    self.safename = str(self)
+
+  def worker_cmdline(self):
+    return ['tools/run_tests/performance/run_worker_rust.sh']
+
+  def worker_port_offset(self):
+    return 100
+
+  def scenarios(self):
+    yield _ping_pong_scenario(
+        'rust_generic_async_streaming_ping_pong', rpc_type='STREAMING',
+        client_type='ASYNC_CLIENT', server_type='ASYNC_GENERIC_SERVER',
+        use_generic_payload=True,
+        categories=[SMOKETEST, SCALABLE])
+
+    yield _ping_pong_scenario(
+        'rust_protobuf_async_streaming_ping_pong', rpc_type='STREAMING',
+        client_type='ASYNC_CLIENT', server_type='ASYNC_SERVER')
+
+    yield _ping_pong_scenario(
+        'rust_protobuf_async_unary_ping_pong', rpc_type='UNARY',
+        client_type='ASYNC_CLIENT', server_type='ASYNC_SERVER',
+        categories=[SMOKETEST, SCALABLE])
+
+    yield _ping_pong_scenario(
+        'rust_protobuf_sync_to_async_unary_ping_pong', rpc_type='UNARY',
+        client_type='SYNC_CLIENT', server_type='ASYNC_SERVER')
+
+    yield _ping_pong_scenario(
+        'rust_protobuf_async_unary_qps_unconstrained', rpc_type='UNARY',
+        client_type='ASYNC_CLIENT', server_type='ASYNC_SERVER',
+        unconstrained_client='async',
+        categories=[SMOKETEST,SCALABLE])
+
+    yield _ping_pong_scenario(
+        'rust_protobuf_async_streaming_qps_unconstrained', rpc_type='STREAMING',
+        client_type='ASYNC_CLIENT', server_type='ASYNC_SERVER',
+        unconstrained_client='async',
+        categories=[SCALABLE])
+
+    yield _ping_pong_scenario(
+        'rust_to_cpp_protobuf_sync_unary_ping_pong', rpc_type='UNARY',
+        client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
+        server_language='c++', async_server_threads=1,
+        categories=[SMOKETEST, SCALABLE])
+
+    yield _ping_pong_scenario(
+        'rust_to_cpp_protobuf_async_streaming_ping_pong', rpc_type='STREAMING',
+        client_type='ASYNC_CLIENT', server_type='ASYNC_SERVER',
+        server_language='c++', async_server_threads=1)
+
+    yield _ping_pong_scenario(
+        'rust_to_cpp_protobuf_async_unary_qps_unconstrained', rpc_type='UNARY',
+        client_type='ASYNC_CLIENT', server_type='ASYNC_SERVER',
+        unconstrained_client='async', server_language='c++',
+        categories=[SCALABLE])
+
+    yield _ping_pong_scenario(
+        'rust_to_cpp_protobuf_sync_to_async_unary_qps_unconstrained', rpc_type='UNARY',
+        client_type='SYNC_CLIENT', server_type='ASYNC_SERVER',
+        unconstrained_client='sync', server_language='c++',
+        categories=[SCALABLE])
+
+    yield _ping_pong_scenario(
+        'cpp_to_rust_protobuf_async_unary_qps_unconstrained', rpc_type='UNARY',
+        client_type='ASYNC_CLIENT', server_type='ASYNC_SERVER',
+        unconstrained_client='async', client_language='c++',
+        categories=[SCALABLE])
+
+    yield _ping_pong_scenario(
+        'rust_protobuf_async_unary_ping_pong_1MB', rpc_type='UNARY',
+        client_type='ASYNC_CLIENT', server_type='ASYNC_SERVER',
+        req_size=1024*1024, resp_size=1024*1024,
+        categories=[SMOKETEST, SCALABLE])
+
+
+  def __str__(self):
+    return 'rust'
+
+
+
 LANGUAGES = {
     'c++' : CXXLanguage(),
     'csharp' : CSharpLanguage(),


### PR DESCRIPTION
RustLanguage scenarios are deleted in a merge conflict. This PR adds these scenarios back, in order to run the benchmark. 