### PR TITLE
Sched combiner closures instead of running to avoid data races

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1226,10 +1226,10 @@ static grpc_closure* add_closure_barrier(grpc_closure* closure) {
   return closure;
 }
 
-static void null_then_run_closure(grpc_closure** closure, grpc_error* error) {
+static void null_then_sched_closure(grpc_closure** closure, grpc_error* error) {
   grpc_closure* c = *closure;
   *closure = nullptr;
-  GRPC_CLOSURE_RUN(c, error);
+  GRPC_CLOSURE_SCHED(c, error);
 }
 
 void grpc_chttp2_complete_closure_step(grpc_chttp2_transport* t,
@@ -1891,7 +1891,7 @@ void grpc_chttp2_maybe_complete_recv_initial_metadata(grpc_chttp2_transport* t,
     }
     grpc_chttp2_incoming_metadata_buffer_publish(&s->metadata_buffer[0],
                                                  s->recv_initial_metadata);
-    null_then_run_closure(&s->recv_initial_metadata_ready, GRPC_ERROR_NONE);
+    null_then_sched_closure(&s->recv_initial_metadata_ready, GRPC_ERROR_NONE);
   }
 }
 
@@ -1971,10 +1971,10 @@ void grpc_chttp2_maybe_complete_recv_message(grpc_chttp2_transport* t,
     s->unprocessed_incoming_frames_buffer_cached_length =
         s->unprocessed_incoming_frames_buffer.length;
     if (error == GRPC_ERROR_NONE && *s->recv_message != nullptr) {
-      null_then_run_closure(&s->recv_message_ready, GRPC_ERROR_NONE);
+      null_then_sched_closure(&s->recv_message_ready, GRPC_ERROR_NONE);
     } else if (s->published_metadata[1] != GRPC_METADATA_NOT_PUBLISHED) {
       *s->recv_message = nullptr;
-      null_then_run_closure(&s->recv_message_ready, GRPC_ERROR_NONE);
+      null_then_sched_closure(&s->recv_message_ready, GRPC_ERROR_NONE);
     }
     GRPC_ERROR_UNREF(error);
   }
@@ -2028,8 +2028,8 @@ void grpc_chttp2_maybe_complete_recv_trailing_metadata(grpc_chttp2_transport* t,
       s->collecting_stats = nullptr;
       grpc_chttp2_incoming_metadata_buffer_publish(&s->metadata_buffer[1],
                                                    s->recv_trailing_metadata);
-      null_then_run_closure(&s->recv_trailing_metadata_finished,
-                            GRPC_ERROR_NONE);
+      null_then_sched_closure(&s->recv_trailing_metadata_finished,
+                              GRPC_ERROR_NONE);
     }
   }
 }


### PR DESCRIPTION
## What have you changed? (mandatory)
Fix segmentation fault bug in https://github.com/grpc/grpc/issues/19923.
This bug is caused by calling the recv_message_ready completion function in advance in some rare cases. So scheduling closure rather than running it can solve this problem.
I also wrote more details about how it happened in comment https://github.com/grpc/grpc/issues/19923.
This PR is the same as https://github.com/grpc/grpc/pull/19531.

## What are the type of the changes? (mandatory)
Bug fix

## How has this PR been tested? (mandatory)
Manual test.
Bug can be reproduced by using a bidirectional streaming RPC(thanks to https://github.com/grpc/grpc/issues/17786).
The probability of this bug happening can be increased by adding a sleep system call in specific position (in `perform_stream_op_locked` function before calling the last `grpc_chttp2_complete_closure_step` function).

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No