### PR TITLE
Backport #18950 to support GCC 9.2.1.

### DIFF
--- a/src/core/lib/gpr/log_linux.cc
+++ b/src/core/lib/gpr/log_linux.cc
@@ -40,7 +40,7 @@
 #include <time.h>
 #include <unistd.h>
 
-static long gettid(void) { return syscall(__NR_gettid); }
+static long sys_gettid(void) { return syscall(__NR_gettid); }
 
 void gpr_log(const char* file, int line, gpr_log_severity severity,
              const char* format, ...) {
@@ -70,7 +70,7 @@ void gpr_default_log(gpr_log_func_args* args) {
   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
   struct tm tm;
   static __thread long tid = 0;
-  if (tid == 0) tid = gettid();
+  if (tid == 0) tid = sys_gettid();
 
   timer = static_cast<time_t>(now.tv_sec);
   final_slash = strrchr(args->file, '/');

--- a/src/core/lib/gpr/log_posix.cc
+++ b/src/core/lib/gpr/log_posix.cc
@@ -30,7 +30,7 @@
 #include <string.h>
 #include <time.h>
 
-static intptr_t gettid(void) { return (intptr_t)pthread_self(); }
+static intptr_t sys_gettid(void) { return (intptr_t)pthread_self(); }
 
 void gpr_log(const char* file, int line, gpr_log_severity severity,
              const char* format, ...) {
@@ -85,7 +85,7 @@ void gpr_default_log(gpr_log_func_args* args) {
   char* prefix;
   gpr_asprintf(&prefix, "%s%s.%09d %7tu %s:%d]",
                gpr_log_severity_string(args->severity), time_buffer,
-               (int)(now.tv_nsec), gettid(), display_file, args->line);
+               (int)(now.tv_nsec), sys_gettid(), display_file, args->line);
 
   fprintf(stderr, "%-70s %s\n", prefix, args->message);
   gpr_free(prefix);

--- a/src/core/lib/iomgr/ev_epollex_linux.cc
+++ b/src/core/lib/iomgr/ev_epollex_linux.cc
@@ -1150,7 +1150,7 @@ static void end_worker(grpc_pollset* pollset, grpc_pollset_worker* worker,
 }
 
 #ifndef NDEBUG
-static long gettid(void) { return syscall(__NR_gettid); }
+static long sys_gettid(void) { return syscall(__NR_gettid); }
 #endif
 
 /* pollset->mu lock must be held by the caller before calling this.
@@ -1170,7 +1170,7 @@ static grpc_error* pollset_work(grpc_pollset* pollset,
 #define WORKER_PTR (&worker)
 #endif
 #ifndef NDEBUG
-  WORKER_PTR->originator = gettid();
+  WORKER_PTR->originator = sys_gettid();
 #endif
   if (grpc_polling_trace.enabled()) {
     gpr_log(GPR_INFO,


### PR DESCRIPTION
Backported https://github.com/grpc/grpc/pull/18950/ so we could support GCC 9.2.1 and up.

Before:

```
[ 26%] Built target c-ares

--- stderr
/home/hoverbear/git/grpc-rs/grpc-sys/grpc/src/core/lib/gpr/log_linux.cc:43:13: error: ambiguating new declaration of ‘long int gettid()’
   43 | static long gettid(void) { return syscall(__NR_gettid); }
      |             ^~~~~~
In file included from /usr/include/unistd.h:1170,
                 from /home/hoverbear/git/grpc-rs/grpc-sys/grpc/src/core/lib/gpr/log_linux.cc:41:
/usr/include/x86_64-linux-gnu/bits/unistd_ext.h:34:16: note: old declaration ‘__pid_t gettid()’
   34 | extern __pid_t gettid (void) __THROW;
      |                ^~~~~~
make[3]: *** [CMakeFiles/gpr.dir/build.make:232: CMakeFiles/gpr.dir/src/core/lib/gpr/log_linux.cc.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/Makefile2:273: CMakeFiles/gpr.dir/all] Error 2
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:125: CMakeFiles/grpc_unsecure.dir/rule] Error 2
make: *** [Makefile:177: grpc_unsecure] Error 2
thread 'main' panicked at '
command did not execute successfully, got: exit code: 2

build script failed, must exit now', /home/hoverbear/.cargo/registry/src/github.com-1ecc6299db9ec823/cmake-0.1.42/src/lib.rs:861:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

After the build is clean, tests all pass.