### PR TITLE
remove duplicated files in cmakelist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3792,20 +3792,7 @@ add_library(upb
   third_party/upb/upb/table.c
   third_party/upb/upb/text_encode.c
   third_party/upb/upb/upb.c
-  src/core/ext/upb-generated/google/protobuf/any.upb.c
   src/core/ext/upb-generated/google/protobuf/descriptor.upb.c
-  src/core/ext/upb-generated/google/protobuf/duration.upb.c
-  src/core/ext/upb-generated/google/protobuf/empty.upb.c
-  src/core/ext/upb-generated/google/protobuf/struct.upb.c
-  src/core/ext/upb-generated/google/protobuf/timestamp.upb.c
-  src/core/ext/upb-generated/google/protobuf/wrappers.upb.c
-  src/core/ext/upbdefs-generated/google/protobuf/any.upbdefs.c
-  src/core/ext/upbdefs-generated/google/protobuf/descriptor.upbdefs.c
-  src/core/ext/upbdefs-generated/google/protobuf/duration.upbdefs.c
-  src/core/ext/upbdefs-generated/google/protobuf/empty.upbdefs.c
-  src/core/ext/upbdefs-generated/google/protobuf/struct.upbdefs.c
-  src/core/ext/upbdefs-generated/google/protobuf/timestamp.upbdefs.c
-  src/core/ext/upbdefs-generated/google/protobuf/wrappers.upbdefs.c
 )
 
 set_target_properties(upb PROPERTIES


### PR DESCRIPTION
This is a quick fix for grpc/grpc#25301. Scripts are untouched as we never regenerate the project.